### PR TITLE
Fixed the bug where degree-to-RA was twice as large as it should be

### DIFF
--- a/participants/DBerke/buggy_function.py
+++ b/participants/DBerke/buggy_function.py
@@ -20,7 +20,7 @@ def angle_to_sexigesimal(angle_in_degrees, decimals=3):
     if math.floor(decimals) != decimals:
         raise OSError('decimals should be an integer!')
 
-    hours_num = angle_in_degrees*24/180
+    hours_num = angle_in_degrees*24/360
     hours = math.floor(hours_num)
 
     min_num = (hours_num - hours)*60


### PR DESCRIPTION
The function to convert angles in degrees to an hour angle was returning twice the value it should have. This change fixes that.

angles_to_degrees(0) -> '0:0:0.000'
angles_to_degrees(180) -> '12:0:0.000'
angles_to_degrees(360) -> '24:0:0.000'